### PR TITLE
fix class variable warning

### DIFF
--- a/lib/whiskey_disk/helpers.rb
+++ b/lib/whiskey_disk/helpers.rb
@@ -5,9 +5,12 @@ def role?(role)
   ENV['WD_ROLES'].split(':').include?(role.to_s)
 end
 
+def hostname
+  @hostname ||= Socket.gethostname
+end
+
 def note(msg=nil)
-  @@hostname ||= Socket.gethostname
-  puts "[#{@@hostname}] #{msg}"
+  puts "[#{hostname}] #{msg}"
 end
 
 # have files of interest changed on this deployment?


### PR DESCRIPTION
```
/home/deploy/apps/beta/shared/bundle/ruby/2.0.0/gems/whiskey_disk-0.7.0/lib/whiskey_disk/helpers.rb:9: warning: class variable access from toplevel
```
